### PR TITLE
Remove the user/group for Distroless

### DIFF
--- a/src/Runtime/EasySwooleRuntime.php
+++ b/src/Runtime/EasySwooleRuntime.php
@@ -22,8 +22,6 @@ final class EasySwooleRuntime extends SymfonyRuntime
             $options['settings'] = \array_merge([
                 // Process
                 Constant::OPTION_DAEMONIZE => 0,
-                Constant::OPTION_GROUP => 'www-data',
-                Constant::OPTION_USER => 'www-data',
                 // Static Handler
                 Constant::OPTION_ENABLE_STATIC_HANDLER => true,
                 Constant::OPTION_DOCUMENT_ROOT => '/var/www/public',


### PR DESCRIPTION
@natepage this will need manual verification- but the Distroless containers do not use the `www-data` user/group. Can you please check if we can simply remove these lines and have it default to using the operating system user, otherwise read from an ENV variable that we can pass into the container.

```
Constant::OPTION_GROUP => 'www-data',
Constant::OPTION_USER => 'www-data',
```